### PR TITLE
MNT: Minimal flit build

### DIFF
--- a/nipreps/__init__.py
+++ b/nipreps/__init__.py
@@ -1,4 +1,0 @@
-try:
-    from ._version import __version__
-except ImportError:
-    __version__ = 'unknown'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,15 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
-build-backend = "hatchling.build"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "nipreps"
-description = "NiPreps official module"
+version = "1.0"
+description = "Namespace package for nipreps utilities"
 readme = "README.md"
+authors = [{name = "The Nipreps developers", email = "nipreps@gmail.com"}]
 license = {file = "LICENSE"}
-maintainers = [
-    {name = "Nipreps developers", email = "nipreps@gmail.com"},
-]
-classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-]
-requires-python = ">=3.8"
-dependencies = [
-]
-dynamic = ["version"]
+classifiers = ["License :: OSI Approved :: Apache Software License"]
 
 [project.urls]
-Homepage = "https://github.com/nipreps/nipreps"
-
-[tool.hatch.version]
-source = "vcs"
-
-[tool.hatch.build.hooks.vcs]
-version-file = "nipreps/_version.py"
+Home = "https://nipreps.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ classifiers = ["License :: OSI Approved :: Apache Software License"]
 
 [project.urls]
 Home = "https://nipreps.org"
+"Source Code" = "https://github.com/nipreps/nipreps"


### PR DESCRIPTION
Unlike hatch, flit is meant to be zero-dependency, fast and reproducible. There is zero need for any of hatch's features in a namespace package.

This does not prevent us from switching in the future, if this package does become more used.

I also dropped most classifiers and requires-python. This will install in any version, and there's nothing to support.